### PR TITLE
allow magnetic store writes during create and update table

### DIFF
--- a/aws-timestream-table/aws-timestream-table.json
+++ b/aws-timestream-table/aws-timestream-table.json
@@ -32,12 +32,12 @@
         "DatabaseName": {
             "description": "The name for the database which the table to be created belongs to.",
             "type": "string",
-            "pattern": "^[a-zA-Z0-9_.-]{3,64}$"
+            "pattern": "^[a-zA-Z0-9_.-]{3,256}$"
         },
         "TableName": {
             "description": "The name for the table. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the table name.",
             "type": "string",
-            "pattern": "^[a-zA-Z0-9_.-]{3,64}$"
+            "pattern": "^[a-zA-Z0-9_.-]{3,256}$"
         },
         "RetentionProperties": {
             "description": "The retention duration of the memory store and the magnetic store.",
@@ -52,6 +52,54 @@
                     "type": "string"
                 }
             },
+            "additionalProperties": false
+        },
+        "MagneticStoreWriteProperties": {
+            "description": "The properties that determine whether magnetic store writes are enabled.",
+            "type": "object",
+            "properties": {
+                "EnableMagneticStoreWrites": {
+                    "description": "Boolean flag indicating whether magnetic store writes are enabled.",
+                    "type": "boolean"
+                },
+                "MagneticStoreRejectedDataLocation": {
+                    "description": "Location to store information about records that were asynchronously rejected during magnetic store writes.",
+                    "type": "object",
+                    "properties": {
+                        "S3Configuration": {
+                            "description": "S3 configuration for location to store rejections from magnetic store writes",
+                            "type": "object",
+                            "properties": {
+                                "BucketName": {
+                                    "description": "The bucket name used to store the data.",
+                                    "type": "string"
+                                },
+                                "ObjectKeyPrefix": {
+                                    "description": "String used to prefix all data in the bucket.",
+                                    "type": "string"
+                                },
+                                "EncryptionOption": {
+                                    "description": "Either SSE_KMS or SSE_S3.",
+                                    "type": "string"
+                                },
+                                "KmsKeyId": {
+                                    "description": "Must be provided if SSE_KMS is specified as the encryption option",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "EncryptionOption",
+                                "BucketName"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "EnableMagneticStoreWrites"
+            ],
             "additionalProperties": false
         },
         "Tags": {

--- a/aws-timestream-table/docs/README.md
+++ b/aws-timestream-table/docs/README.md
@@ -15,6 +15,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#databasename" title="DatabaseName">DatabaseName</a>" : <i>String</i>,
         "<a href="#tablename" title="TableName">TableName</a>" : <i>String</i>,
         "<a href="#retentionproperties" title="RetentionProperties">RetentionProperties</a>" : <i><a href="retentionproperties.md">RetentionProperties</a></i>,
+        "<a href="#magneticstorewriteproperties" title="MagneticStoreWriteProperties">MagneticStoreWriteProperties</a>" : <i><a href="magneticstorewriteproperties.md">MagneticStoreWriteProperties</a></i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>
     }
 }
@@ -28,6 +29,7 @@ Properties:
     <a href="#databasename" title="DatabaseName">DatabaseName</a>: <i>String</i>
     <a href="#tablename" title="TableName">TableName</a>: <i>String</i>
     <a href="#retentionproperties" title="RetentionProperties">RetentionProperties</a>: <i><a href="retentionproperties.md">RetentionProperties</a></i>
+    <a href="#magneticstorewriteproperties" title="MagneticStoreWriteProperties">MagneticStoreWriteProperties</a>: <i><a href="magneticstorewriteproperties.md">MagneticStoreWriteProperties</a></i>
     <a href="#tags" title="Tags">Tags</a>: <i>
       - <a href="tag.md">Tag</a></i>
 </pre>
@@ -42,7 +44,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Pattern_: <code>^[a-zA-Z0-9_.-]{3,64}$</code>
+_Pattern_: <code>^[a-zA-Z0-9_.-]{3,256}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
@@ -54,7 +56,7 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^[a-zA-Z0-9_.-]{3,64}$</code>
+_Pattern_: <code>^[a-zA-Z0-9_.-]{3,256}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
@@ -65,6 +67,16 @@ The retention duration of the memory store and the magnetic store.
 _Required_: No
 
 _Type_: <a href="retentionproperties.md">RetentionProperties</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MagneticStoreWriteProperties
+
+The properties that determine whether magnetic store writes are enabled.
+
+_Required_: No
+
+_Type_: <a href="magneticstorewriteproperties.md">MagneticStoreWriteProperties</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-timestream-table/docs/magneticstorewriteproperties.md
+++ b/aws-timestream-table/docs/magneticstorewriteproperties.md
@@ -1,0 +1,44 @@
+# AWS::Timestream::Table MagneticStoreWriteProperties
+
+The properties that determine whether magnetic store writes are enabled.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#enablemagneticstorewrites" title="EnableMagneticStoreWrites">EnableMagneticStoreWrites</a>" : <i>Boolean</i>,
+    "<a href="#magneticstorerejecteddatalocation" title="MagneticStoreRejectedDataLocation">MagneticStoreRejectedDataLocation</a>" : <i><a href="magneticstorewriteproperties.md">MagneticStoreWriteProperties</a></i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#enablemagneticstorewrites" title="EnableMagneticStoreWrites">EnableMagneticStoreWrites</a>: <i>Boolean</i>
+<a href="#magneticstorerejecteddatalocation" title="MagneticStoreRejectedDataLocation">MagneticStoreRejectedDataLocation</a>: <i><a href="magneticstorewriteproperties.md">MagneticStoreWriteProperties</a></i>
+</pre>
+
+## Properties
+
+#### EnableMagneticStoreWrites
+
+Boolean flag indicating whether magnetic store writes are enabled.
+
+_Required_: Yes
+
+_Type_: Boolean
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MagneticStoreRejectedDataLocation
+
+_Required_: No
+
+_Type_: <a href="magneticstorewriteproperties.md">MagneticStoreWriteProperties</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-timestream-table/inputs/inputs_1_create.json
+++ b/aws-timestream-table/inputs/inputs_1_create.json
@@ -5,6 +5,15 @@
     "MemoryStoreRetentionPeriodInHours": "48",
     "MagneticStoreRetentionPeriodInDays": "3650"
   },
+  "MagneticStoreWriteProperties": {
+    "EnableMagneticStoreWrites": true,
+    "MagneticStoreRejectedDataLocation": {
+      "S3Configuration": {
+        "BucketName": "{{ARRContractTestsS3BucketNameExport}}",
+        "EncryptionOption": "SSE_S3"
+      }
+    }
+  },
   "Tags": [
     {
       "Key" : "testKey",

--- a/aws-timestream-table/inputs/inputs_1_update.json
+++ b/aws-timestream-table/inputs/inputs_1_update.json
@@ -5,6 +5,9 @@
     "MemoryStoreRetentionPeriodInHours": "48",
     "MagneticStoreRetentionPeriodInDays": "1800"
   },
+  "MagneticStoreWriteProperties": {
+    "EnableMagneticStoreWrites": false
+  },
   "Tags": [
     {
       "Key" : "stage",

--- a/aws-timestream-table/src/main/java/software/amazon/timestream/table/CreateHandler.java
+++ b/aws-timestream-table/src/main/java/software/amazon/timestream/table/CreateHandler.java
@@ -26,6 +26,7 @@ import com.amazonaws.services.timestreamwrite.model.CreateTableResult;
 import com.amazonaws.services.timestreamwrite.model.InternalServerException;
 import com.amazonaws.services.timestreamwrite.model.InvalidEndpointException;
 import com.amazonaws.services.timestreamwrite.model.ResourceNotFoundException;
+import com.amazonaws.services.timestreamwrite.model.MagneticStoreWriteProperties;
 import com.amazonaws.services.timestreamwrite.model.ServiceQuotaExceededException;
 import com.amazonaws.services.timestreamwrite.model.ThrottlingException;
 import com.amazonaws.services.timestreamwrite.model.ValidationException;
@@ -67,11 +68,14 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                     ));
         }
 
+        final MagneticStoreWriteProperties magneticStoreWriteProperties = MagneticStoreWritePropertiesModelConverter.convert(model.getMagneticStoreWriteProperties());
+
         final CreateTableRequest createTableRequest =
                 new CreateTableRequest()
                         .withDatabaseName(model.getDatabaseName())
                         .withTableName(model.getTableName())
-                        .withRetentionProperties(RetentionPropertiesModelConverter.convert(model.getRetentionProperties()));
+                        .withRetentionProperties(RetentionPropertiesModelConverter.convert(model.getRetentionProperties()))
+                        .withMagneticStoreWriteProperties(magneticStoreWriteProperties);
 
         final Set<Tag> tags = TagHelper.convertToSet(
                 TagHelper.generateTagsForCreate(model, request));

--- a/aws-timestream-table/src/main/java/software/amazon/timestream/table/MagneticStoreRejectedDataLocationModelConverter.java
+++ b/aws-timestream-table/src/main/java/software/amazon/timestream/table/MagneticStoreRejectedDataLocationModelConverter.java
@@ -1,0 +1,26 @@
+package software.amazon.timestream.table;
+
+/**
+ * Class for conversion between Timestream magnetic store rejected data location model and what is defined in the resource provider package.
+ *
+ */
+class MagneticStoreRejectedDataLocationModelConverter {
+    public static com.amazonaws.services.timestreamwrite.model.MagneticStoreRejectedDataLocation convert(MagneticStoreRejectedDataLocation magneticStoreRejectedDataLocation) {
+        if (magneticStoreRejectedDataLocation == null) {
+            return null;
+        }
+
+        return new com.amazonaws.services.timestreamwrite.model.MagneticStoreRejectedDataLocation()
+                .withS3Configuration(S3ConfigurationModelConverter.convert(magneticStoreRejectedDataLocation.getS3Configuration()));
+    }
+
+    public static MagneticStoreRejectedDataLocation convert(com.amazonaws.services.timestreamwrite.model.MagneticStoreRejectedDataLocation sdkModel) {
+        if (sdkModel == null) {
+            return null;
+        }
+
+        return MagneticStoreRejectedDataLocation.builder()
+                .s3Configuration(S3ConfigurationModelConverter.convert(sdkModel.getS3Configuration()))
+                .build();
+    }
+}

--- a/aws-timestream-table/src/main/java/software/amazon/timestream/table/MagneticStoreWritePropertiesModelConverter.java
+++ b/aws-timestream-table/src/main/java/software/amazon/timestream/table/MagneticStoreWritePropertiesModelConverter.java
@@ -1,0 +1,28 @@
+package software.amazon.timestream.table;
+
+/**
+ * Class for conversion between Timestream magnetic store writes properties model and what is defined in the resource provider package.
+ *
+ */
+class MagneticStoreWritePropertiesModelConverter {
+    public static com.amazonaws.services.timestreamwrite.model.MagneticStoreWriteProperties convert(MagneticStoreWriteProperties magneticStoreWriteProperties) {
+        if (magneticStoreWriteProperties == null) {
+            return null;
+        }
+
+        return new com.amazonaws.services.timestreamwrite.model.MagneticStoreWriteProperties()
+                .withEnableMagneticStoreWrites(magneticStoreWriteProperties.getEnableMagneticStoreWrites())
+                .withMagneticStoreRejectedDataLocation(MagneticStoreRejectedDataLocationModelConverter.convert(magneticStoreWriteProperties.getMagneticStoreRejectedDataLocation()));
+    }
+
+    public static MagneticStoreWriteProperties convert(com.amazonaws.services.timestreamwrite.model.MagneticStoreWriteProperties sdkModel) {
+        if (sdkModel == null) {
+            return null;
+        }
+
+        return MagneticStoreWriteProperties.builder()
+                .enableMagneticStoreWrites(sdkModel.getEnableMagneticStoreWrites())
+                .magneticStoreRejectedDataLocation(MagneticStoreRejectedDataLocationModelConverter.convert(sdkModel.getMagneticStoreRejectedDataLocation()))
+                .build();
+    }
+}

--- a/aws-timestream-table/src/main/java/software/amazon/timestream/table/S3ConfigurationModelConverter.java
+++ b/aws-timestream-table/src/main/java/software/amazon/timestream/table/S3ConfigurationModelConverter.java
@@ -1,0 +1,32 @@
+package software.amazon.timestream.table;
+
+/**
+ * Class for conversion between Timestream magnetic store rejected s3 configuration model and what is defined in the resource provider package.
+ *
+ */
+class S3ConfigurationModelConverter {
+    public static com.amazonaws.services.timestreamwrite.model.S3Configuration convert(S3Configuration s3Configuration) {
+        if (s3Configuration == null) {
+            return null;
+        }
+
+        return new com.amazonaws.services.timestreamwrite.model.S3Configuration()
+                .withBucketName(s3Configuration.getBucketName())
+                .withObjectKeyPrefix(s3Configuration.getObjectKeyPrefix())
+                .withEncryptionOption(s3Configuration.getEncryptionOption())
+                .withKmsKeyId(s3Configuration.getKmsKeyId());
+    }
+
+    public static S3Configuration convert(com.amazonaws.services.timestreamwrite.model.S3Configuration sdkModel) {
+        if (sdkModel == null) {
+            return null;
+        }
+
+        return S3Configuration.builder()
+                .bucketName(sdkModel.getBucketName())
+                .objectKeyPrefix(sdkModel.getObjectKeyPrefix())
+                .encryptionOption(sdkModel.getEncryptionOption())
+                .kmsKeyId(sdkModel.getKmsKeyId())
+                .build();
+    }
+}

--- a/aws-timestream-table/src/main/java/software/amazon/timestream/table/UpdateHandler.java
+++ b/aws-timestream-table/src/main/java/software/amazon/timestream/table/UpdateHandler.java
@@ -24,6 +24,7 @@ import com.amazonaws.services.timestreamwrite.model.InternalServerException;
 import com.amazonaws.services.timestreamwrite.model.InvalidEndpointException;
 import com.amazonaws.services.timestreamwrite.model.ResourceNotFoundException;
 import com.amazonaws.services.timestreamwrite.model.RetentionProperties;
+import com.amazonaws.services.timestreamwrite.model.MagneticStoreWriteProperties;
 import com.amazonaws.services.timestreamwrite.model.TagResourceRequest;
 import com.amazonaws.services.timestreamwrite.model.ThrottlingException;
 import com.amazonaws.services.timestreamwrite.model.UntagResourceRequest;
@@ -79,11 +80,14 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                 retentionProperties = RetentionPropertiesModelConverter.convert(model.getRetentionProperties());
             }
 
+            MagneticStoreWriteProperties magneticStoreWriteProperties = MagneticStoreWritePropertiesModelConverter.convert(model.getMagneticStoreWriteProperties());
+
             final UpdateTableRequest updateTableRequest =
                     new UpdateTableRequest()
                             .withDatabaseName(model.getDatabaseName())
                             .withTableName(model.getTableName())
-                            .withRetentionProperties(retentionProperties);
+                            .withRetentionProperties(retentionProperties)
+                            .withMagneticStoreWriteProperties(magneticStoreWriteProperties);
 
             final UpdateTableResult updateTableResult =
                     this.proxy.injectCredentialsAndInvoke(updateTableRequest, timestreamClient::updateTable);

--- a/aws-timestream-table/src/test/java/software/amazon/timestream/table/MagneticStoreWritePropertiesModelConverterTest.java
+++ b/aws-timestream-table/src/test/java/software/amazon/timestream/table/MagneticStoreWritePropertiesModelConverterTest.java
@@ -1,0 +1,117 @@
+package software.amazon.timestream.table;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class MagneticStoreWritePropertiesModelConverterTest {
+
+    @Test
+    void shouldConvertSDKModelFromUluruModel() {
+        S3Configuration uluruS3configuration = S3Configuration.builder()
+                .bucketName("BucketName")
+                .objectKeyPrefix("ObjectKeyPrefix")
+                .encryptionOption("EncryptionOption")
+                .kmsKeyId("KmsKeyId")
+                .build();
+
+        MagneticStoreRejectedDataLocation uluruRejectedDataLocation = MagneticStoreRejectedDataLocation.builder()
+                .s3Configuration(uluruS3configuration)
+                .build();
+
+        MagneticStoreWriteProperties uluruModel = MagneticStoreWriteProperties.builder()
+                .enableMagneticStoreWrites(true)
+                .magneticStoreRejectedDataLocation(uluruRejectedDataLocation)
+                .build();
+
+        com.amazonaws.services.timestreamwrite.model.S3Configuration sdkS3ConfigurationModel =
+            new com.amazonaws.services.timestreamwrite.model.S3Configuration()
+                    .withBucketName("BucketName")
+                    .withObjectKeyPrefix("ObjectKeyPrefix")
+                    .withEncryptionOption("EncryptionOption")
+                    .withKmsKeyId("KmsKeyId");
+
+        com.amazonaws.services.timestreamwrite.model.MagneticStoreRejectedDataLocation sdkDataLocationModel =
+                new com.amazonaws.services.timestreamwrite.model.MagneticStoreRejectedDataLocation()
+                    .withS3Configuration(sdkS3ConfigurationModel);
+
+        com.amazonaws.services.timestreamwrite.model.MagneticStoreWriteProperties sdkModel =
+                new com.amazonaws.services.timestreamwrite.model.MagneticStoreWriteProperties()
+                        .withEnableMagneticStoreWrites(true)
+                        .withMagneticStoreRejectedDataLocation(sdkDataLocationModel);
+
+        assertThat(sdkModel).isEqualTo(MagneticStoreWritePropertiesModelConverter.convert(uluruModel));
+    }
+
+    @Test
+    void shouldConvertUluruModelFromSDKModel() {
+        S3Configuration uluruS3configuration = S3Configuration.builder()
+                .bucketName("BucketName")
+                .objectKeyPrefix("ObjectKeyPrefix")
+                .encryptionOption("EncryptionOption")
+                .kmsKeyId("KmsKeyId")
+                .build();
+
+        MagneticStoreRejectedDataLocation uluruRejectedDataLocation = MagneticStoreRejectedDataLocation.builder()
+                .s3Configuration(uluruS3configuration)
+                .build();
+
+        MagneticStoreWriteProperties uluruModel = MagneticStoreWriteProperties.builder()
+                .enableMagneticStoreWrites(true)
+                .magneticStoreRejectedDataLocation(uluruRejectedDataLocation)
+                .build();
+
+        com.amazonaws.services.timestreamwrite.model.S3Configuration sdkS3ConfigurationModel =
+                new com.amazonaws.services.timestreamwrite.model.S3Configuration()
+                        .withBucketName("BucketName")
+                        .withObjectKeyPrefix("ObjectKeyPrefix")
+                        .withEncryptionOption("EncryptionOption")
+                        .withKmsKeyId("KmsKeyId");
+
+        com.amazonaws.services.timestreamwrite.model.MagneticStoreRejectedDataLocation sdkDataLocationModel =
+                new com.amazonaws.services.timestreamwrite.model.MagneticStoreRejectedDataLocation()
+                        .withS3Configuration(sdkS3ConfigurationModel);
+
+        com.amazonaws.services.timestreamwrite.model.MagneticStoreWriteProperties sdkModel =
+                new com.amazonaws.services.timestreamwrite.model.MagneticStoreWriteProperties()
+                        .withEnableMagneticStoreWrites(true)
+                        .withMagneticStoreRejectedDataLocation(sdkDataLocationModel);
+
+        assertThat(uluruModel).isEqualTo(MagneticStoreWritePropertiesModelConverter.convert(sdkModel));
+    }
+
+    @Test
+    void shouldConvertSDKModelFromUluruModelWithInputAsNull() {
+        assertNull(MagneticStoreWritePropertiesModelConverter.convert((MagneticStoreWriteProperties) null));
+    }
+
+    @Test
+    void shouldConvertUluruModelFromSDKModelWithInputAsNull() {
+        assertNull(MagneticStoreWritePropertiesModelConverter.convert(
+                (com.amazonaws.services.timestreamwrite.model.MagneticStoreWriteProperties) null));
+    }
+
+    @Test
+    void shouldConvertSDKLocationModelFromUluruModelWithInputAsNull() {
+        assertNull(MagneticStoreRejectedDataLocationModelConverter.convert((MagneticStoreRejectedDataLocation) null));
+    }
+
+    @Test
+    void shouldConvertUluruLocationModelFromSDKModelWithInputAsNull() {
+        assertNull(MagneticStoreRejectedDataLocationModelConverter.convert(
+                (com.amazonaws.services.timestreamwrite.model.MagneticStoreRejectedDataLocation) null));
+    }
+
+    @Test
+    void shouldConvertSDKS3ConfigurationModelFromUluruModelWithInputAsNull() {
+        assertNull(S3ConfigurationModelConverter.convert((S3Configuration) null));
+    }
+
+    @Test
+    void shouldConvertUluruS3ConfigurationModelFromSDKModelWithInputAsNull() {
+        assertNull(S3ConfigurationModelConverter.convert(
+                (com.amazonaws.services.timestreamwrite.model.S3Configuration) null));
+    }
+
+}


### PR DESCRIPTION
*Description of changes:*
Add magnetic store writes properties field to create and update table. Also updates the documentation to properly reflect that we allow table names up to 256 characters. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
